### PR TITLE
Change base to "/r-spatial-guide/"

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -1,5 +1,5 @@
 module.exports = {
-  base: '/',
+  base: '/r-spatial-guide/',
   dest: 'docs',
   locales: {
     '/': {


### PR DESCRIPTION
Fix #3 

https://vuepress.vuejs.org/guide/assets.html#base-url によれば

> If your site is deployed to a non-root URL, you will need to set the `base` option in `.vuepress/config.js`. For example, if you plan to deploy your site to `https://foo.github.io/bar/`, then `base` should be set to `"/bar/"` (it should always start and end with a slash). 

とのことなので、これが正しそうな気がします。が、このレポジトリのビルド方法わからなかったので手元で試せていません。全然違ったらすみません...